### PR TITLE
Change Github Copilot keymap

### DIFF
--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -1,3 +1,6 @@
+vim.g.copilot_no_tab_map = true
+vim.api.nvim_set_keymap("i", "<C-j>", 'copilot#Accept("<CR>")', { silent = true, expr = true })
+
 return {
   "github/copilot.vim",
 }


### PR DESCRIPTION
Instead of tab, it is now CTRL+j whenever in insert mode.