### PR TITLE
Change Signature Help keymap to CTRL+i

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -394,7 +394,7 @@ local on_attach = function(_, bufnr)
 
   -- See `:help K` for why this keymap
   nmap('K', vim.lsp.buf.hover, 'Hover Documentation')
-  nmap('<C-k>', vim.lsp.buf.signature_help, 'Signature Documentation')
+  nmap('<C-i>', vim.lsp.buf.signature_help, 'Signature Documentation')
 
   -- Lesser used LSP functionality
   nmap('gD', vim.lsp.buf.declaration, '[G]oto [D]eclaration')


### PR DESCRIPTION
The original keymap was CTRL+k which was interfering with vim-tmux-navigator.