### PR TITLE
Change Neotree keymap

### DIFF
--- a/after/plugin/keymap.lua
+++ b/after/plugin/keymap.lua
@@ -1,1 +1,3 @@
 vim.keymap.set('n', '<leader><F5>', vim.cmd.UndotreeToggle, { desc = "Display undo history" })
+vim.keymap.set('n', '<leader>nr', vim.cmd.NeoTreeReveal, { desc = "Reveal file in File Explorer" })
+vim.keymap.set('n', '<leader>nt', vim.cmd.NeoTreeShowToggle, { desc = "Toggle File Explorer" })

--- a/lua/custom/plugins/filetree.lua
+++ b/lua/custom/plugins/filetree.lua
@@ -233,7 +233,5 @@ return {
           }
         }
       })
-
-      vim.cmd([[nnoremap \ :Neotree reveal<cr>]])
     end,
 }


### PR DESCRIPTION
This removes the reveal keymap which is (\) and adds the following:

- `<leader>nr` - NeoTreeReveal
- `<leader>nt` - NeoTreeShowToggle